### PR TITLE
Adding lstat function.

### DIFF
--- a/src/lib/safefs.coffee
+++ b/src/lib/safefs.coffee
@@ -175,6 +175,17 @@ safefs =
 		# Chain
 		safefs
 
+	# Lstat
+	# next(err,stat)
+	lstat: (path,next) ->
+		safefs.openFile (closeFile) ->
+			fsUtil.lstat path, (err,stat) ->
+				closeFile()
+				return next(err,stat)
+
+		# Chain
+		safefs
+
 	# Stat
 	# next(err,stat)
 	stat: (path,next) ->


### PR DESCRIPTION
This adds safefs.lstat, which is needed to handling broken links - such as bevry/watchr#42
